### PR TITLE
Changed cursor color to white for Sidewalk Chalk

### DIFF
--- a/xcode-themes/Sidewalk Chalk.dvtcolortheme
+++ b/xcode-themes/Sidewalk Chalk.dvtcolortheme
@@ -35,7 +35,7 @@
 	<key>DVTSourceTextBlockDimBackgroundColor</key>
 	<string>0.5 0.5 0.5 1</string>
 	<key>DVTSourceTextInsertionPointColor</key>
-	<string>0 0 0 1</string>
+	<string>1 1 1 1</string>
 	<key>DVTSourceTextInvisiblesColor</key>
 	<string>0.5 0.5 0.5 1</string>
 	<key>DVTSourceTextSelectionColor</key>


### PR DESCRIPTION
The default cursor color is dark color, so I have changed it to white, just like Monokai.dvtcolortheme
